### PR TITLE
Build fixes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ allprojects {
         maven("https://maven.neoforged.net/releases")
         maven("https://thedarkcolour.github.io/KotlinForForge/")
         maven("https://maven.ftb.dev/releases/")
+        maven("https://maven.blamejared.com/")
     }
 
     java {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ allprojects {
         maven("https://maven.impactdev.net/repository/development/")
         maven("https://maven.neoforged.net/releases")
         maven("https://thedarkcolour.github.io/KotlinForForge/")
-        maven("https://maven.ftb.dev")
+        maven("https://maven.ftb.dev/releases/")
     }
 
     java {

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     minecraft("com.mojang:minecraft:${property("minecraft_version")}")
     mappings(loom.officialMojangMappings())
     modImplementation("net.fabricmc:fabric-loader:${property("fabric_loader_version")}")
-    modImplementation("dev.ftb.mods:ftblibrary-fabric:2101.1.3")
+    modImplementation("dev.ftb.mods:ftb-library-fabric:2101.1.3")
 
     modRuntimeOnly("net.fabricmc.fabric-api:fabric-api:${property("fabric_api_version")}")
     modImplementation("net.fabricmc:fabric-language-kotlin:${property("fabric_kotlin")}")

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -49,8 +49,6 @@ dependencies {
     // Remove the next line if you don't want to depend on the API
     modImplementation "dev.architectury:architectury-neoforge:${rootProject.architectury_version}"
 
-    modImplementation("com.cobblemon:neoforge:${property("cobblemon_version")}")
-
     forgeRuntimeLibrary("thedarkcolour:kotlinforforge-neoforge:5.3.0") {
         exclude group: "net.neoforged.fancymodloader", module: "loader"
     }


### PR DESCRIPTION
Minor fixes for dependency build issues; we'll probably want to completely remove `neoforge` from this package?

1. Updated FTB Maven repo's URL
2. Added blamejared's Maven repo for FTB's JEI dependency
3. Removed the neoforge version of cobblemon since that was causing arcane build issues and almost certainly isn't necessary?